### PR TITLE
remove fstring

### DIFF
--- a/gtfs_go_dialog.py
+++ b/gtfs_go_dialog.py
@@ -84,7 +84,7 @@ class GTFSGoDialog(QtWidgets.QDialog):
         """
         if data.get('region') is None:
             return data["name"]
-        return f'[{data["region"]}] {data["name"]}'
+        return '[' + data["region"] + ']' + data["name"]
 
     def execution(self):
         loader = GTFSGoLoader(

--- a/gtfs_go_loader.py
+++ b/gtfs_go_loader.py
@@ -143,7 +143,7 @@ class Downloader(QThread):
             os.makedirs(self.output_dir, exist_ok=True)
 
         self.download_path = os.path.join(
-            self.output_dir, f'{int(time.time())}.zip')
+            self.output_dir, str(int(time.time())) + '.zip')
 
     def run(self):
         data = urllib.request.urlopen(self.zipfile_url).read()


### PR DESCRIPTION
close #18 

A version of Python on QGIS can be lower than 3.7 and in that version "f-string" is not implemented.