### PR TITLE
Develop

### DIFF
--- a/gtfs_parser/__main__.py
+++ b/gtfs_parser/__main__.py
@@ -82,13 +82,15 @@ class GTFSParser:
             lambda stop_id: self.get_similar_stop_tuple(stop_id, delimiter, max_distance_degree)).apply(pd.Series)
         self.dataframes['stops']['position_id'] = self.dataframes['stops']['similar_stops_centroid'].map(
             latlon_to_str)
+        self.dataframes['stops']['unique_id'] = self.dataframes['stops']['similar_stop_id'] + \
+            self.dataframes['stops']['position_id']
 
         # sometimes stop_name accidently becomes pd.Series instead of str.
         self.dataframes['stops']['similar_stop_name'] = self.dataframes['stops']['similar_stop_name'].map(
             lambda val: val if type(val) == str else val.stop_name)
 
         self.similar_stops_df = self.dataframes['stops'].drop_duplicates(
-            subset='position_id')[[
+            subset='unique_id')[[
                 'position_id', 'similar_stop_id', 'similar_stop_name', 'similar_stops_centroid']].copy()
 
     def read_stops(self, ignore_no_route=False) -> list:

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=GTFS-GO
 qgisMinimumVersion=3.0
 description=The plugin to extract GTFS data and to show routes and stops.
-version=2.0.1
+version=2.0.2
 author=MIERUNE Inc.
 email=info@mierune.co.jp
 


### PR DESCRIPTION
fix drop-duplicates methods

before
drop same position_id stops
postiton_id: similar_stops_centroid as String
probrem is sometimes not similar stops can have same position_id (when not similar stops have completely same coordinates)


after
drop same unique_id stops
unique_id: similar_stop_id + position_id