### PR TITLE
Update gtfs parser interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Smaller number of rules is prefered.
 
 3.  stop_name and distance
 
-    -   unifying stops having same stop_name and near to each in certain extent - 0.01 degree in terms of lonlat-plane
+    -   unifying stops having same stop_name and near to each in certain extent - 0.003 degree in terms of lonlat-plane
     -   new stop_id is the first stop's one in grouped stops ordered by stop_id ascending.
 
 #### unifying result

--- a/gtfs_go_dialog.py
+++ b/gtfs_go_dialog.py
@@ -29,6 +29,7 @@ import shutil
 import tempfile
 import urllib
 import uuid
+import csv
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
@@ -227,7 +228,7 @@ class GTFSGoDialog(QDialog):
                 "aggregated_csv": "",
             }
 
-            gtfs = gtfs_parser.GTFS(feed_info["path"])
+            gtfs = gtfs_parser.GTFSFactory(feed_info["path"])
 
             if self.ui.simpleCheckbox.isChecked():
                 routes_geojson = {
@@ -277,7 +278,7 @@ class GTFSGoDialog(QDialog):
                     "type": "FeatureCollection",
                     "features": aggregator.read_interpolated_stops(),
                 }
-
+                stop_relations = aggregator.read_stop_relations()
                 # write
                 written_files["aggregated_routes"] = os.path.join(
                     output_dir, "aggregated_routes.geojson"
@@ -301,12 +302,12 @@ class GTFSGoDialog(QDialog):
                 with open(
                     written_files["aggregated_csv"],
                     mode="w",
-                    encoding="cp932",
+                    encoding="utf-8",
                     errors="ignore",
                 ) as f:
-                    aggregator.gtfs["stops"][
-                        ["stop_id", "stop_name", "similar_stop_id", "similar_stop_name"]
-                    ].to_csv(f, index=False)
+                    writer = csv.DictWriter(f, fieldnames=stop_relations[0].keys())
+                    writer.writeheader()
+                    writer.writerows(stop_relations)
 
             self.show_geojson(
                 feed_info["group"],
@@ -424,6 +425,7 @@ class GTFSGoDialog(QDialog):
                 os.path.basename(aggregated_csv).split(".")[0],
                 "ogr",
             )
+            aggregated_csv_vlayer.setProviderEncoding("UTF-8")
 
             QgsProject.instance().addMapLayer(aggregated_csv_vlayer, False)
             group.insertLayer(0, aggregated_csv_vlayer)

--- a/gtfs_go_dialog.py
+++ b/gtfs_go_dialog.py
@@ -304,6 +304,7 @@ class GTFSGoDialog(QDialog):
                     mode="w",
                     encoding="utf-8",
                     errors="ignore",
+                    newline='',
                 ) as f:
                     writer = csv.DictWriter(f, fieldnames=stop_relations[0].keys())
                     writer.writeheader()


### PR DESCRIPTION
### Close Issues
* #77

### Description（変更内容）
With the update of gtfs-parser, the parsing and aggregation process will be several times faster.
* MIERUNE/gtfs-parser#11

The following changes were made to update gtfs_parser. 
* Change the instantiation of gtfs_parser from the constructor to `GTFSFactory`.
* Change the way of getting aggregated stop relations  to call `read_stop_relations()`
* Change the encoding of aggregated stop relations csv file from cp932 to utf-8 and set the encoding to the layer.
* Decrease the max distance of stop unification by name from 0.01 degree to 0.003 degree. 

I suggest that this be a major version up since the required Python and QGIS versions have been raised.

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->
Please check in QGIS on your Mac OS.